### PR TITLE
CVE-2025-42999 and minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ## Joint Release by Onapsis & Mandiant
 
-Onapsis and Mandiant have collaborated to release an open-source tool to assist SAP customers in identifying potential compromise related to **CVE-2025-31324**, a critical 0-day vulnerability in SAP NetWeaver Java systems.
+Onapsis and Mandiant have collaborated to release an open-source tool to assist SAP customers in identifying potential compromise related to **CVE-2025-31324** and **CVE-2025-42999**, a critical 0-day vulnerability in SAP NetWeaver Java systems.
 
 This tool is intended for local, **white-box execution** by system administrators with access to potentially affected environments. It supports vulnerability assessment, simple compromise assessment and artifact collection.
 
 ### Features
 
 This tool currently supports the following functionality:
-* Detects whether the system is vulnerable to CVE-2025-31324
+* Detects whether the system is vulnerable to CVE-2025-31324 and CVE-2025-42999
 * Identifies known Indicators of Compromise (IOCs)
 * Scans for unknown web-executable files in known exploit paths
 * Collects suspicious files into a structured ZIP archive with a manifest for future forensic analysis
@@ -19,7 +19,7 @@ This tool currently supports the following functionality:
 
 > **LICENSE INFORMATION**: This tool is released under the Apache 2.0 open source license. Please see bundled license information.
 
-> **DISCLAIMER**: This tool is intended to support urgent investigation and response efforts related to the active exploitation of CVE-2025-31324.  This tool is under active development and may be updated as new intelligence is discovered by Onapsis Research Labs, Mandiant, or other public sources.
+> **DISCLAIMER**: This tool is intended to support urgent investigation and response efforts related to the active exploitation of CVE-2025-31324 and CVE-2025-42999.  This tool is under active development and may be updated as new intelligence is discovered by Onapsis Research Labs, Mandiant, or other public sources.
 
 This tool automates checking of vulnerability and IOC information running in live OS with the permissions of the user executing the script. This is NOT a substitute for forensic analysis or advanced incident response. Sophisticated attackers often clean up evidence of their intrusion while deploying rootkits and leveraging techniques to evade detection.
 
@@ -78,8 +78,10 @@ Mounted filesystem at `/mnt/sapserver` (component vulnerable, single instance sc
 <code>python3 onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment.py /mnt/sapserver/usr/sap/SID/J00 --single</code>
 
 ```
-[INFO] Found component at: /mnt/sapserver/usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF
-[CRITICAL] Known vulnerable component version found: 7.5028.20230722071537.0000
+[INFO] Found component at: /mnt/sapserver/usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF, checking CVE-2025-31324... for CVE-2025-31324
+[CRITICAL] Known vulnerable component version found: 7.5028.20230722071537.0000 for CVE-2025-31324
+[INFO] Found component at: /mnt/sapserver/usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF, checking CVE-2025-31324... for CVE-2025-42999
+[CRITICAL] Known vulnerable component version found: 7.5028.20230722071537.0000 for CVE-2025-42999
 [CRITICAL] Found known IoC file signature: /mnt/sapserver/usr/sap/SID/J00/j2ee/cluster/apps/sap.com/irj/servlet_jsp/irj/root/helper.jsp: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 [WARNING] Found suspicious unfamiliar file: /mnt/sapserver/usr/sap/SID/J00/j2ee/cluster/apps/sap.com/irj/servlet_jsp/irj/work/JEE_jsp_some-name_timestamp.java: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 [WARNING] Found suspicious unfamiliar file: /mnt/sapserver/usr/sap/SID/J00/j2ee/cluster/apps/sap.com/irj/servlet_jsp/irj/work/sync/JEE_jsp_some-name_timestamp.class: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -139,8 +141,10 @@ Live filesystem at `/` (component patched, non vulnerable):
 <code>./onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment /</code>
 
 ```
-[INFO] Found component at: /usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF
-[INFO] Component found but version is patched: 7.5031.20250418122224.0000
+[INFO] Found component at: /usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF, checking CVE-2025-31324...
+[INFO] Component found but version is patched: 7.5031.20250418122224.0000 for CVE-2025-31324
+[INFO] Found component at: /usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF, checking CVE-2025-42999...
+[CRITICAL] Known vulnerable component version found: 7.5031.20250418122224.0000 for CVE-2025-42999
 [INFO] No suspicious files founds
 [INFO] Found log file at: /usr/sap/SID/J00/j2ee/cluster/server0/log/system/httpaccess/responses_00.0.trc
 [INFO] No exploit attempts detected
@@ -169,7 +173,8 @@ Live filesystem at `C:\` (component not installed, non vulnerable):
 <code>onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment.exe C:\ </code>
 
 ```
-[INFO] Component not found
+[INFO] Component not found for CVE-2025-31324
+[INFO] Component not found for CVE-2025-42999
 [INFO] No suspicious files founds
 [WARNING] No log folders found!
 ==============================================================================

--- a/onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment.py
+++ b/onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment.py
@@ -20,7 +20,7 @@ whitebox execution by the administrator of a potentially affected system.
 
 This tool:
 
-- Checks if system is vulnerable to CVE-2025-31324
+- Checks if system is vulnerable to CVE-2025-31324 and CVE-2025-42999
 - Detects known IOCs
 - Scans for unknown web executables in exploit paths
 - Packages suspicious files into a ZIP with manifest
@@ -60,7 +60,7 @@ import time
 import zipfile
 
 
-__version__ = "3.3.11"
+__version__ = "4.4.12"
 
 GITHUB_REPO = (
     "Onapsis/Onapsis-Mandiant-CVE-2025-31324-Vuln-Compromise-Assessment"
@@ -74,7 +74,9 @@ SAP_JAVA_APP_PATH = f'{SAP_JAVA_BASE_PATH}/apps/sap.com'
 
 COMPONENT_PATH = f'{SAP_JAVA_APP_PATH}/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF'
 VERSION_AFFECTED = "1000"   # 7.1x and later
-VERSION_MATRIX = {
+
+# [CVE-2025-31324] Missing Authorization check in SAP NetWeaver (Visual Composer development server)
+VERSION_MATRIX_3594142 = {
     "5020": "20250430",
     "5021": "20250430",
     "5022": "20250430",
@@ -87,6 +89,22 @@ VERSION_MATRIX = {
     "5029": "20250418",
     "5030": "20250418",
     "5031": "20250418",
+}
+
+# [CVE-2025-42999] Insecure Deserialization in SAP NetWeaver (Visual Composer development server)
+VERSION_MATRIX_3604119 = {
+    "5020": "20250509",
+    "5021": "20250509",
+    "5022": "20250509",
+    "5023": "20250509",
+    "5024": "20250509",
+    "5025": "20250509",
+    "5026": "20250509",
+    "5027": "20250509",
+    "5028": "20250509",
+    "5029": "20250509",
+    "5030": "20250509",
+    "5031": "20250509",
 }
 
 SUSPICIOUS_GLOB = [
@@ -349,14 +367,14 @@ This suggests that, based on current logs, there is no evidence of attacker acti
 logger = logging.getLogger(__name__)
 
 
-def check_component(path):
+def check_component(path, version_matrix, cve):
     manifest_files = path.glob(os.path.join(SAP_PREFIX, COMPONENT_PATH))
     vulnerable = None
     version = None
-    min_sp = min(VERSION_MATRIX.keys())
-    max_sp = max(VERSION_MATRIX.keys())
+    min_sp = min(version_matrix.keys())
+    max_sp = max(version_matrix.keys())
     for mf in manifest_files:
-        print(f"[INFO] Found component at: {mf}")
+        print(f"[INFO] Found component at: {mf}, checking {cve}...")
         with open(mf) as manifest:
             for manifest_line in manifest:
                 try:
@@ -376,19 +394,19 @@ def check_component(path):
                             logger.debug("Version newer: %s", sp)
                             vulnerable = False
                         else:
-                            logger.debug("Version check %s < %s", timestamp, VERSION_MATRIX[sp])
-                            vulnerable =  timestamp < VERSION_MATRIX[sp]
+                            logger.debug("Version check %s < %s", timestamp, version_matrix[sp])
+                            vulnerable =  timestamp < version_matrix[sp]
                         break
                 except Exception as ex:
                     print(f"[WARNING] Cannot parse {manifest_line}: {ex}")
         if vulnerable is not None:
             break
     if vulnerable is None:
-        print("[INFO] Component not found")
+        print("[INFO] Component not found for {cve}")
     elif not vulnerable:
-        print(f"[INFO] Component found but version is patched: {version}")
+        print(f"[INFO] Component found but version is patched: {version} for {cve}")
     else:
-        print(f"[CRITICAL] Known vulnerable component version found: {version}")
+        print(f"[CRITICAL] Known vulnerable component version found: {version} for {cve}")
     return vulnerable
 
 
@@ -782,7 +800,12 @@ def main():
         if not args.offline:
             check_for_updates()
         if check_java_folder(args.path, args.single):
-            vulnerable = check_component(args.path)
+            vulnerable = {}
+            for cve, version_matrix in {
+                    "CVE-2025-31324": VERSION_MATRIX_3594142,
+                    "CVE-2025-42999": VERSION_MATRIX_3604119,
+                    }.items():
+                vulnerable[cve] = check_component(args.path, version_matrix, cve)
             file_list, known_ioc_list = find_suspicious_files(args.path)
             log_files, log_entries = analyze_logs(args.path, file_list)
             timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")

--- a/onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment.py
+++ b/onapsis-mandiant-CVE-2025-31324-vuln-compromise-assessment.py
@@ -24,8 +24,9 @@ This tool:
 - Detects known IOCs
 - Scans for unknown web executables in exploit paths
 - Packages suspicious files into a ZIP with manifest
-* Analyzes HTTP access logs for potential exploit and post-exploit activity
-* Exports log entries for matching responses in a CSV
+- Analyzes HTTP access logs for potential exploit and post-exploit activity
+- Analyzes JAVA Default Traces logs for exploitation activity
+- Exports log entries for matching responses in a CSV
 
 DISCLAIMER: This tool is provided from Onapsis and Mandiant via open source
 license Apache 2.0, as a contribution to the security, incident response, and
@@ -140,12 +141,26 @@ LOG_PATTERN_SAP = re.compile(
 LOG_PATTERN_CLF = re.compile(
     r'(?P<ip>\S+)\s(?P<rfc931>\S+)\s(?P<authuser>\S+)\s\[(?P<date>.*?)\]\s"(?P<method>\S+)\s(?P<resource>\S+)\s*(?P<protocol>\S+)?"\s(?P<status_code>\d{3})\s(?P<size>\d+)\s*(?P<extra>.*)?'
 )
-LOG_COLUMNS = "date", "ip", "method", "resource", "status_code", "size", "extra"
+LOG_COLUMNS = "date", "ip", "method", "resource", "status_code", "size", "extra", "filename"
+
+LOG_RULES = [
+    lambda log_entry, context:
+        "exploit" if log_entry["path"].lower() == "/developmentserver/metadatauploader" and
+                     log_entry["params"].get("CONTENTTYPE", "").upper() == "MODEL" and
+                     log_entry["params"].get("CLIENT", "").upper() == "1" and
+                     log_entry["method"] in ("POST", "GET", "HEAD") else None,
+    lambda log_entry, context:
+        "webshell" if log_entry["path"].startswith("/irj/") and
+                      log_entry["path"].endswith(context["webshells"]) and
+                      log_entry["status_code"] == 200 else None,
+    lambda log_entry, context:
+        "webshell" if fnmatch(log_entry["path"], "/irj/*.jsp") else None,
+]
 
 TRACE_PATH_GLOB = f'{SAP_JAVA_BASE_PATH}/*/log/'
 TRACE_FILES_GLOB = 'defaultTrace*.trc*'
 
-TRACE_COLUMNS = "date", "severity", "category", "log_id", "application", "location", "user", "session", "transaction", "thread", "log_type", "message", "result"
+TRACE_COLUMNS = "date", "severity", "category", "log_id", "application", "location", "user", "session", "transaction", "thread", "log_type", "message", "result", "filename"
 
 TRACE_PATTERN_V2 = re.compile(
         r"#(?P<version>[^#]*)#"
@@ -409,14 +424,14 @@ def find_suspicious_files(path):
 
 def parse_log_line(filename, text):
     pattern = LOG_PATTERN_CLF if '-clf.trc' in filename else LOG_PATTERN_SAP
-    match = re.match(pattern, text.strip())
+    match = re.match(pattern, text)
     date_format = "%d/%b/%Y:%H:%M:%S %z" if '-clf.trc' in filename else "%b %d, %Y %I:%M:%S %p"
-    log_entry = {}
+    log_entry = {"filename": filename}
     if match:
         log_entry.update(match.groupdict())
-        log_entry["status_code"] = int(log_entry["status_code"])
-        log_entry["size"] = int(log_entry["size"])
         try:
+            log_entry["status_code"] = int(log_entry["status_code"])
+            log_entry["size"] = int(log_entry["size"])
             log_entry["date"] = datetime.strptime(log_entry["date"].strip(), date_format)
             url = urlparse(log_entry["resource"])
             log_entry["path"] = url.path.lower()
@@ -427,7 +442,7 @@ def parse_log_line(filename, text):
 
 
 def analyze_logs(path, suspicious_list):
-    webshells = tuple(KNOWN_IOC_NAMES + [path.name for path in suspicious_list])
+    context = {"webshells": tuple(KNOWN_IOC_NAMES + [path.name for path in suspicious_list])}
     log_path = os.path.join(SAP_PREFIX, LOG_PATH_GLOB)
     log_folders = list(path.glob(log_path))
     log_files = list(path.glob(log_path + LOG_FILES_GLOB))
@@ -441,36 +456,29 @@ def analyze_logs(path, suspicious_list):
                 log_file_normalized = os.path.normcase(log_file)
                 for log_text in log:
                     try:
-                        log_text = log_text.strip()
-                        log_entry = parse_log_line(log_file_normalized, log_text)
-                        if not log_entry:
+                        log_text = log_text.strip("\n").strip("\r")
+                        log_entry = parse_log_line(log_file_normalized, log_text.strip())
+                        if not log_entry or (log_text.startswith("<!--") and log_text.endswith("-->")):
                             continue
                         status = "{} {}".format(log_entry["status_code"], http.client.responses.get(log_entry["status_code"]))
-                        # look for exploit attempts
-                        # POST /developmentserver/metadatauploader?CONTENTTYPE=MODEL&CLIENT=1
-                        if (log_entry["path"].lower() == "/developmentserver/metadatauploader" and
-                            log_entry["params"].get("CONTENTTYPE", "").upper() == "MODEL" and
-                            log_entry["params"].get("CLIENT", "").upper() == "1" and
-                            log_entry["method"] in ("POST", "GET", "HEAD")):
-                            print(f"[WARNING] Exploit attempt detected: {log_text}")
-                            log_entry["exploit"] = True
-                            log_entries.append(log_entry)
-                            exploit_attempts += 1
-                        # look for webshell and post-exploit artifact access: eg. /irj/helper.jsp
-                        if (log_entry["path"].startswith("/irj/") and
-                            log_entry["path"].endswith(webshells) and
-                            log_entry["status_code"] == 200):
-                            print(f"[CRITICAL] Web executable access detected: {log_text}")
-                            log_entry["webshell"] = True
-                            log_entries.append(log_entry)
-                            executable_accesses += 1
-                        elif fnmatch(log_entry["path"], "/irj/*.jsp"):
-                            # Show suspicious artifacts with random names and/or unsuccessfull access (404, 500)
-                            print(f"[NOTICE] Web executable attempt detected: {log_text}")
-                            if log_entry["status_code"] == 200:
-                                log_entry["webshell"] = True
-                                executable_accesses += 1
-                            log_entries.append(log_entry)
+                        for rule in LOG_RULES:
+                            result = rule(log_entry, context)
+                            if result:
+                                log_entry[result] = True
+                                if log_entry not in log_entries:
+                                    log_entries.append(log_entry)
+                            if log_entry.get("exploit"):
+                                # explot attempt: eg. POST /developmentserver/metadatauploader?CONTENTTYPE=MODEL&CLIENT=1
+                                print(f"[WARNING] Exploit attempt detected: {log_text}")
+                                exploit_attempts += 1
+                            if log_entry.get("webshell"):
+                                # post-exploit artifact access: eg. /irj/helper.jsp
+                                if log_entry["status_code"] == 200:
+                                    print(f"[CRITICAL] Web executable access detected: {log_text}")
+                                    executable_accesses += 1
+                                else:
+                                    # Show suspicious artifacts with random names and/or unsuccessfull access (404, 500)
+                                    print(f"[NOTICE] Web executable attempt detected: {log_text}")
                     except Exception as ex:
                         print(f"[ERROR] Cannot parse {log_text}: {ex}")
                         raise
@@ -506,6 +514,7 @@ def parse_trace_file(file_path):
             if match:
                 event = match.groupdict()
                 event["message"] = event["message"].strip()
+                event["filename"] = file_path
                 logger.debug("Match: %s", event)
                 yield event
                 multiline = []


### PR DESCRIPTION
[CVE-2025-42999](https://www.cve.org/CVERecord?id=CVE-2025-42999): added a check for new version of patches in https://me.sap.com/notes/3604119 

```
[INFO] Found component at: /usr/sap/SID/J00/j2ee/cluster/apps/sap.com/devserver_metadataupload_ear/servlet_jsp/developmentserver/root/META-INF/MANIFEST.MF, checking CVE-2025-42999...
[CRITICAL] Known vulnerable component version found: 7.5031.20250418122224.0000 for CVE-2025-42999
```

Also, minor changes to include log filename in CSV and other small refactors.